### PR TITLE
fix: ensure CSS imports from manifest arrays are resolved and emitted…

### DIFF
--- a/vite-spring-boot-jte/src/main/java/io/github/wimdeblauwe/vite/spring/boot/jte/ViteJteEntriesHandler.java
+++ b/vite-spring-boot-jte/src/main/java/io/github/wimdeblauwe/vite/spring/boot/jte/ViteJteEntriesHandler.java
@@ -31,7 +31,7 @@ class ViteJteEntriesHandler {
 
         ManifestEntry manifestEntry = linkResolver.getManifestEntry(entry);
         if (manifestEntry != null) {
-            manifestEntry.css().forEach(linkedCss -> addEntryIfMissing(linkedCss, true));
+            manifestEntry.css().forEach(this::addBuiltCssIfMissing);
             manifestEntry.imports().forEach(this::handleImportedResource);
         }
     }
@@ -52,12 +52,19 @@ class ViteJteEntriesHandler {
         }
     }
 
+    private void addBuiltCssIfMissing(final String linkedCss) {
+        if (references.add(linkedCss)) {
+            String resolvedCss = linkResolver.resolveBuiltAssetPath(linkedCss);
+            htmlEntries.add(generateCssLinkTag(resolvedCss));
+        }
+    }
+
     private void handleImportedResource(final String resource) {
         ManifestEntry manifestEntry = linkResolver.getManifestEntry(resource);
         String file = "/" + manifestEntry.file();
         addEntryIfMissing(file, false);
 
-        manifestEntry.css().forEach(linkedCss -> addEntryIfMissing(linkedCss, false));
+        manifestEntry.css().forEach(this::addBuiltCssIfMissing);
         manifestEntry.imports().forEach(this::handleImportedResource);
     }
 }

--- a/vite-spring-boot-thymeleaf/src/main/java/io/github/wimdeblauwe/vite/spring/boot/thymeleaf/ViteTagProcessor.java
+++ b/vite-spring-boot-thymeleaf/src/main/java/io/github/wimdeblauwe/vite/spring/boot/thymeleaf/ViteTagProcessor.java
@@ -111,10 +111,8 @@ public class ViteTagProcessor extends AbstractElementModelProcessor {
       if (manifestEntry != null) {
         if (manifestEntry.css() != null) {
           for (String linkedCss : manifestEntry.css()) {
-            linkResolver.resolveResource(linkedCss)
-                    .ifPresent(resource -> {
-                      executeIfNotOutputtedYet(value, () -> htmlEntries.add(tagFactory.generateCssLinkTag(resource)));
-                    });
+            String resolvedCss = linkResolver.resolveBuiltAssetPath(linkedCss);
+            executeIfNotOutputtedYet(linkedCss, () -> htmlEntries.add(tagFactory.generateCssLinkTag(resolvedCss)));
           }
         }
 
@@ -141,7 +139,8 @@ public class ViteTagProcessor extends AbstractElementModelProcessor {
 
       if (manifestEntry.css() != null) {
         for (String linkedCss : manifestEntry.css()) {
-          executeIfNotOutputtedYet(linkedCss, () -> htmlEntries.add(tagFactory.generateCssLinkTag(linkedCss)));
+          String resolvedCss = linkResolver.resolveBuiltAssetPath(linkedCss);
+          executeIfNotOutputtedYet(linkedCss, () -> htmlEntries.add(tagFactory.generateCssLinkTag(resolvedCss)));
         }
       }
 

--- a/vite-spring-boot-thymeleaf/src/test/java/io/github/wimdeblauwe/vite/spring/boot/thymeleaf/ViteTagProcessorTest.java
+++ b/vite-spring-boot-thymeleaf/src/test/java/io/github/wimdeblauwe/vite/spring/boot/thymeleaf/ViteTagProcessorTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ViteTagProcessorTest {
 
   private TemplateEngine templateEngine;
+  private TemplateEngine issue19TemplateEngine;
 
   @BeforeEach
   void setUp() throws Exception {
@@ -30,15 +31,15 @@ class ViteTagProcessorTest {
     templateResolver.setTemplateMode(TemplateMode.HTML);
     templateResolver.setCharacterEncoding("UTF-8");
 
-    // Create and configure template engine
+    JsonMapper jsonMapper = JsonMapper.builder().build();
+
+    // Create and configure template engine with example manifest
     templateEngine = new SpringTemplateEngine();
     templateEngine.setTemplateResolver(templateResolver);
 
     ViteConfigurationProperties properties = new ViteConfigurationProperties(ViteConfigurationProperties.Mode.BUILD,
                                                                              new ClassPathResource("vite-manifest-example.json"), null, "static",null, null);
     ViteDevServerConfigurationProperties devServerConfigurationProperties = new ViteDevServerConfigurationProperties("localhost", 5431);
-
-    JsonMapper jsonMapper = JsonMapper.builder().build();
 
     ViteManifestReader manifestReader = new ViteManifestReader(jsonMapper, properties);
     manifestReader.init();
@@ -49,6 +50,23 @@ class ViteTagProcessorTest {
             devServerConfigurationProperties,
             linkResolver);
     templateEngine.addDialect(viteDialect);
+
+    // Create and configure template engine with issue-19 manifest
+    issue19TemplateEngine = new SpringTemplateEngine();
+    issue19TemplateEngine.setTemplateResolver(templateResolver);
+
+    ViteConfigurationProperties issue19Properties = new ViteConfigurationProperties(ViteConfigurationProperties.Mode.BUILD,
+                                                                                    new ClassPathResource("vite-manifest-issue-19.json"), null, "src/main/javascript", null, null);
+
+    ViteManifestReader issue19ManifestReader = new ViteManifestReader(jsonMapper, issue19Properties);
+    issue19ManifestReader.init();
+    ViteLinkResolver issue19LinkResolver = new ViteLinkResolver(issue19Properties, devServerConfigurationProperties, issue19ManifestReader);
+
+    ViteDialect issue19ViteDialect = new ViteDialect(
+            issue19Properties,
+            devServerConfigurationProperties,
+            issue19LinkResolver);
+    issue19TemplateEngine.addDialect(issue19ViteDialect);
   }
 
   @Test
@@ -71,5 +89,38 @@ class ViteTagProcessorTest {
             .contains("<link rel=\"stylesheet\" href=\"/assets/application-BJA3xOLB.css\">")
             .contains("<script type=\"module\" src=\"/assets/ButtonBar-8UAhfTQ4.js\"></script>")
             .containsOnlyOnce("<script type=\"module\" src=\"/assets/client-3T5L5Tgj.js\">");
+  }
+
+  @Test
+  void shouldEmitCssFromEntryCssArray() {
+    // Issue 19 - CSS from manifest entry css arrays should be emitted
+    // even when the CSS file does not have its own standalone manifest entry
+    Context context = new Context();
+    String result = issue19TemplateEngine.process("issue-19-entry-with-css", context);
+
+    assertThat(result)
+            .contains("<link rel=\"stylesheet\" href=\"/assets/app_form._C7kVfoY.css\">");
+  }
+
+  @Test
+  void shouldEmitCssFromImportedChunks() {
+    // Issue 19 - CSS from imported chunks should be emitted with proper / prefix
+    // app-form.js imports _calendar.C4S5ojBx.min.js which has css: ["assets/calendar.fn7WE02H.css"]
+    Context context = new Context();
+    String result = issue19TemplateEngine.process("issue-19-entry-with-css", context);
+
+    assertThat(result)
+            .contains("<link rel=\"stylesheet\" href=\"/assets/calendar.fn7WE02H.css\">");
+  }
+
+  @Test
+  void shouldEmitCssFromDirectEntryCssArray() {
+    // Issue 19 - common.js has css: ["assets/common.TBP_tahU.css"]
+    // This CSS should be emitted even though it has no standalone manifest entry
+    Context context = new Context();
+    String result = issue19TemplateEngine.process("issue-19-entry-with-imported-css", context);
+
+    assertThat(result)
+            .contains("<link rel=\"stylesheet\" href=\"/assets/common.TBP_tahU.css\">");
   }
 }

--- a/vite-spring-boot-thymeleaf/src/test/java/io/github/wimdeblauwe/vite/spring/boot/thymeleaf/ViteTagProcessorTest.java
+++ b/vite-spring-boot-thymeleaf/src/test/java/io/github/wimdeblauwe/vite/spring/boot/thymeleaf/ViteTagProcessorTest.java
@@ -6,7 +6,6 @@ import io.github.wimdeblauwe.vite.spring.boot.ViteLinkResolver;
 import io.github.wimdeblauwe.vite.spring.boot.ViteManifestReader;
 import tools.jackson.databind.json.JsonMapper;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.io.ClassPathResource;
 import org.thymeleaf.TemplateEngine;
@@ -19,60 +18,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ViteTagProcessorTest {
 
-  private TemplateEngine templateEngine;
-  private TemplateEngine issue19TemplateEngine;
-
-  @BeforeEach
-  void setUp() throws Exception {
-    // Configure Thymeleaf
-    ClassLoaderTemplateResolver templateResolver = new ClassLoaderTemplateResolver();
-    templateResolver.setPrefix("/templates/");
-    templateResolver.setSuffix(".html");
-    templateResolver.setTemplateMode(TemplateMode.HTML);
-    templateResolver.setCharacterEncoding("UTF-8");
-
-    JsonMapper jsonMapper = JsonMapper.builder().build();
-
-    // Create and configure template engine with example manifest
-    templateEngine = new SpringTemplateEngine();
-    templateEngine.setTemplateResolver(templateResolver);
-
-    ViteConfigurationProperties properties = new ViteConfigurationProperties(ViteConfigurationProperties.Mode.BUILD,
-                                                                             new ClassPathResource("vite-manifest-example.json"), null, "static",null, null);
-    ViteDevServerConfigurationProperties devServerConfigurationProperties = new ViteDevServerConfigurationProperties("localhost", 5431);
-
-    ViteManifestReader manifestReader = new ViteManifestReader(jsonMapper, properties);
-    manifestReader.init();
-    ViteLinkResolver linkResolver = new ViteLinkResolver(properties, devServerConfigurationProperties, manifestReader);
-
-    ViteDialect viteDialect = new ViteDialect(
-            properties,
-            devServerConfigurationProperties,
-            linkResolver);
-    templateEngine.addDialect(viteDialect);
-
-    // Create and configure template engine with issue-19 manifest
-    issue19TemplateEngine = new SpringTemplateEngine();
-    issue19TemplateEngine.setTemplateResolver(templateResolver);
-
-    ViteConfigurationProperties issue19Properties = new ViteConfigurationProperties(ViteConfigurationProperties.Mode.BUILD,
-                                                                                    new ClassPathResource("vite-manifest-issue-19.json"), null, "src/main/javascript", null, null);
-
-    ViteManifestReader issue19ManifestReader = new ViteManifestReader(jsonMapper, issue19Properties);
-    issue19ManifestReader.init();
-    ViteLinkResolver issue19LinkResolver = new ViteLinkResolver(issue19Properties, devServerConfigurationProperties, issue19ManifestReader);
-
-    ViteDialect issue19ViteDialect = new ViteDialect(
-            issue19Properties,
-            devServerConfigurationProperties,
-            issue19LinkResolver);
-    issue19TemplateEngine.addDialect(issue19ViteDialect);
-  }
-
   @Test
-  void shouldProcessTemplate() {
+  void shouldProcessTemplate() throws Exception {
+    TemplateEngine engine = createTemplateEngine("vite-manifest-example.json", "static");
     Context context = new Context();
-    String result = templateEngine.process("example", context);
+    String result = engine.process("example", context);
 
     assertThat(result)
             .contains("<link rel=\"stylesheet\" href=\"/assets/application-BJA3xOLB.css\">")
@@ -81,9 +31,10 @@ class ViteTagProcessorTest {
   }
 
   @Test
-  void shouldOnlyOutputSameEntryOnce() {
+  void shouldOnlyOutputSameEntryOnce() throws Exception {
+    TemplateEngine engine = createTemplateEngine("vite-manifest-example.json", "static");
     Context context = new Context();
-    String result = templateEngine.process("example-many-entries", context);
+    String result = engine.process("example-many-entries", context);
 
     assertThat(result)
             .contains("<link rel=\"stylesheet\" href=\"/assets/application-BJA3xOLB.css\">")
@@ -92,35 +43,66 @@ class ViteTagProcessorTest {
   }
 
   @Test
-  void shouldEmitCssFromEntryCssArray() {
+  void shouldEmitCssFromEntryCssArray() throws Exception {
     // Issue 19 - CSS from manifest entry css arrays should be emitted
     // even when the CSS file does not have its own standalone manifest entry
+    TemplateEngine engine = createTemplateEngine("vite-manifest-issue-19.json", "src/main/javascript");
     Context context = new Context();
-    String result = issue19TemplateEngine.process("issue-19-entry-with-css", context);
+    String result = engine.process("issue-19-entry-with-css", context);
 
     assertThat(result)
             .contains("<link rel=\"stylesheet\" href=\"/assets/app_form._C7kVfoY.css\">");
   }
 
   @Test
-  void shouldEmitCssFromImportedChunks() {
+  void shouldEmitCssFromImportedChunks() throws Exception {
     // Issue 19 - CSS from imported chunks should be emitted with proper / prefix
     // app-form.js imports _calendar.C4S5ojBx.min.js which has css: ["assets/calendar.fn7WE02H.css"]
+    TemplateEngine engine = createTemplateEngine("vite-manifest-issue-19.json", "src/main/javascript");
     Context context = new Context();
-    String result = issue19TemplateEngine.process("issue-19-entry-with-css", context);
+    String result = engine.process("issue-19-entry-with-css", context);
 
     assertThat(result)
             .contains("<link rel=\"stylesheet\" href=\"/assets/calendar.fn7WE02H.css\">");
   }
 
   @Test
-  void shouldEmitCssFromDirectEntryCssArray() {
+  void shouldEmitCssFromDirectEntryCssArray() throws Exception {
     // Issue 19 - common.js has css: ["assets/common.TBP_tahU.css"]
     // This CSS should be emitted even though it has no standalone manifest entry
+    TemplateEngine engine = createTemplateEngine("vite-manifest-issue-19.json", "src/main/javascript");
     Context context = new Context();
-    String result = issue19TemplateEngine.process("issue-19-entry-with-imported-css", context);
+    String result = engine.process("issue-19-entry-with-imported-css", context);
 
     assertThat(result)
             .contains("<link rel=\"stylesheet\" href=\"/assets/common.TBP_tahU.css\">");
+  }
+
+  private TemplateEngine createTemplateEngine(String manifestResource, String staticResourcesPrefix) throws Exception {
+    ClassLoaderTemplateResolver templateResolver = new ClassLoaderTemplateResolver();
+    templateResolver.setPrefix("/templates/");
+    templateResolver.setSuffix(".html");
+    templateResolver.setTemplateMode(TemplateMode.HTML);
+    templateResolver.setCharacterEncoding("UTF-8");
+
+    JsonMapper jsonMapper = JsonMapper.builder().build();
+
+    ViteConfigurationProperties properties = new ViteConfigurationProperties(ViteConfigurationProperties.Mode.BUILD,
+                                                                             new ClassPathResource(manifestResource), null, staticResourcesPrefix, null, null);
+    ViteDevServerConfigurationProperties devServerConfigurationProperties = new ViteDevServerConfigurationProperties("localhost", 5431);
+
+    ViteManifestReader manifestReader = new ViteManifestReader(jsonMapper, properties);
+    manifestReader.init();
+    ViteLinkResolver linkResolver = new ViteLinkResolver(properties, devServerConfigurationProperties, manifestReader);
+
+    ViteDialect viteDialect = new ViteDialect(
+        properties,
+        devServerConfigurationProperties,
+        linkResolver);
+
+    SpringTemplateEngine engine = new SpringTemplateEngine();
+    engine.setTemplateResolver(templateResolver);
+    engine.addDialect(viteDialect);
+    return engine;
   }
 }

--- a/vite-spring-boot-thymeleaf/src/test/resources/templates/issue-19-entry-with-css.html
+++ b/vite-spring-boot-thymeleaf/src/test/resources/templates/issue-19-entry-with-css.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html
+        xmlns:vite="http://www.thymeleaf.org/vite">
+<head>
+    <title>Issue 19 - Entry with CSS</title>
+    <vite:vite>
+        <vite:entry value="/bundles/app-form.js"></vite:entry>
+    </vite:vite>
+</head>
+<body>
+<h1>Issue 19</h1>
+</body>
+</html>

--- a/vite-spring-boot-thymeleaf/src/test/resources/templates/issue-19-entry-with-imported-css.html
+++ b/vite-spring-boot-thymeleaf/src/test/resources/templates/issue-19-entry-with-imported-css.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html
+        xmlns:vite="http://www.thymeleaf.org/vite">
+<head>
+    <title>Issue 19 - Entry with imported CSS</title>
+    <vite:vite>
+        <vite:entry value="/bundles/common.js"></vite:entry>
+    </vite:vite>
+</head>
+<body>
+<h1>Issue 19</h1>
+</body>
+</html>

--- a/vite-spring-boot-thymeleaf/src/test/resources/vite-manifest-issue-19.json
+++ b/vite-spring-boot-thymeleaf/src/test/resources/vite-manifest-issue-19.json
@@ -1,0 +1,545 @@
+{
+  "_autosubmit.r8iHgQvC.min.js": {
+    "file": "assets/autosubmit.r8iHgQvC.min.js",
+    "name": "autosubmit"
+  },
+  "_calendar.C4S5ojBx.min.js": {
+    "file": "assets/calendar.C4S5ojBx.min.js",
+    "name": "calendar",
+    "imports": [
+      "_index.wj8pcfcc.min.js",
+      "_index.Bh91bsRU.min.js",
+      "_locale-resolver.D1koifEE.min.js",
+      "_fetch.Bc7I7bIE.min.js"
+    ],
+    "css": [
+      "assets/calendar.fn7WE02H.css"
+    ]
+  },
+  "_calendar.fn7WE02H.css": {
+    "file": "assets/calendar.fn7WE02H.css",
+    "src": "_calendar.fn7WE02H.css"
+  },
+  "_fetch.Bc7I7bIE.min.js": {
+    "file": "assets/fetch.Bc7I7bIE.min.js",
+    "name": "fetch"
+  },
+  "_hotwire-turbo-progressbar.CUHRTaOR.min.js": {
+    "file": "assets/hotwire-turbo-progressbar.CUHRTaOR.min.js",
+    "name": "hotwire-turbo-progressbar",
+    "imports": [
+      "_turbo.es2017-esm.DHvWW2v7.min.js"
+    ]
+  },
+  "_index.BCp-oihN.min.js": {
+    "file": "assets/index.BCp-oihN.min.js",
+    "name": "index",
+    "imports": [
+      "_index.Bh91bsRU.min.js"
+    ]
+  },
+  "_index.Bh91bsRU.min.js": {
+    "file": "assets/index.Bh91bsRU.min.js",
+    "name": "index"
+  },
+  "_index.D_CwqlHt.min.js": {
+    "file": "assets/index.D_CwqlHt.min.js",
+    "name": "index",
+    "imports": [
+      "_jquery.CYvPhWWh.min.js",
+      "_tooltip.V9gAR6FA.min.js"
+    ]
+  },
+  "_index.wj8pcfcc.min.js": {
+    "file": "assets/index.wj8pcfcc.min.js",
+    "name": "index",
+    "imports": [
+      "_index.Bh91bsRU.min.js"
+    ]
+  },
+  "_jquery.CYvPhWWh.min.js": {
+    "file": "assets/jquery.CYvPhWWh.min.js",
+    "name": "jquery"
+  },
+  "_jquery.tablesorter.combined.D9ypodMB.min.js": {
+    "file": "assets/jquery.tablesorter.combined.D9ypodMB.min.js",
+    "name": "jquery.tablesorter.combined",
+    "imports": [
+      "_jquery.CYvPhWWh.min.js"
+    ]
+  },
+  "_locale-resolver.D1koifEE.min.js": {
+    "file": "assets/locale-resolver.D1koifEE.min.js",
+    "name": "locale-resolver",
+    "imports": [
+      "_index.Bh91bsRU.min.js"
+    ]
+  },
+  "_max-chars.DwBgcc3G.min.js": {
+    "file": "assets/max-chars.DwBgcc3G.min.js",
+    "name": "max-chars"
+  },
+  "_popover.ae9y68QG.min.js": {
+    "file": "assets/popover.ae9y68QG.min.js",
+    "name": "popover",
+    "imports": [
+      "_jquery.CYvPhWWh.min.js"
+    ]
+  },
+  "_send-get-days-request-for-turn-of-the-year.N0-OrWVW.min.js": {
+    "file": "assets/send-get-days-request-for-turn-of-the-year.N0-OrWVW.min.js",
+    "name": "send-get-days-request-for-turn-of-the-year",
+    "imports": [
+      "_fetch.Bc7I7bIE.min.js",
+      "_index.wj8pcfcc.min.js"
+    ]
+  },
+  "_tab.DRceIxvF.min.js": {
+    "file": "assets/tab.DRceIxvF.min.js",
+    "name": "tab",
+    "imports": [
+      "_jquery.CYvPhWWh.min.js"
+    ]
+  },
+  "_tooltip.V9gAR6FA.min.js": {
+    "file": "assets/tooltip.V9gAR6FA.min.js",
+    "name": "tooltip",
+    "imports": [
+      "_jquery.CYvPhWWh.min.js"
+    ]
+  },
+  "_turbo-before-render-restore.BN3LCdBL.min.js": {
+    "file": "assets/turbo-before-render-restore.BN3LCdBL.min.js",
+    "name": "turbo-before-render-restore",
+    "imports": [
+      "src/main/javascript/components/datepicker/index.js"
+    ]
+  },
+  "_turbo.es2017-esm.DHvWW2v7.min.js": {
+    "file": "assets/turbo.es2017-esm.DHvWW2v7.min.js",
+    "name": "turbo.es2017-esm"
+  },
+  "node_modules/date-fns/esm/locale/de-AT/index.js": {
+    "file": "assets/index.DSg2a4Uh.min.js",
+    "name": "index",
+    "src": "node_modules/date-fns/esm/locale/de-AT/index.js",
+    "isDynamicEntry": true,
+    "imports": [
+      "_index.BCp-oihN.min.js",
+      "_index.Bh91bsRU.min.js"
+    ]
+  },
+  "node_modules/date-fns/esm/locale/de/index.js": {
+    "file": "assets/index.E_D5Olis.min.js",
+    "name": "index",
+    "src": "node_modules/date-fns/esm/locale/de/index.js",
+    "isDynamicEntry": true,
+    "imports": [
+      "_index.BCp-oihN.min.js",
+      "_index.Bh91bsRU.min.js"
+    ]
+  },
+  "node_modules/date-fns/esm/locale/el/index.js": {
+    "file": "assets/index.yT1O6zju.min.js",
+    "name": "index",
+    "src": "node_modules/date-fns/esm/locale/el/index.js",
+    "isDynamicEntry": true,
+    "imports": [
+      "_index.Bh91bsRU.min.js"
+    ]
+  },
+  "node_modules/date-fns/esm/locale/en-GB/index.js": {
+    "file": "assets/index.CMH_g7DM.min.js",
+    "name": "index",
+    "src": "node_modules/date-fns/esm/locale/en-GB/index.js",
+    "isDynamicEntry": true,
+    "imports": [
+      "_index.Bh91bsRU.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/absences-overview.js": {
+    "file": "assets/absences_overview.DnLNFLkL.min.js",
+    "name": "absences_overview",
+    "src": "src/main/javascript/bundles/absences-overview.js",
+    "isEntry": true,
+    "imports": [
+      "_jquery.CYvPhWWh.min.js",
+      "_jquery.tablesorter.combined.D9ypodMB.min.js"
+    ],
+    "css": [
+      "assets/absences_overview.D3I0_cTc.css"
+    ]
+  },
+  "src/main/javascript/bundles/account-form.js": {
+    "file": "assets/account_form.DciBKjhr.min.js",
+    "name": "account_form",
+    "src": "src/main/javascript/bundles/account-form.js",
+    "isEntry": true,
+    "imports": [
+      "src/main/javascript/components/datepicker/index.js",
+      "src/main/javascript/bundles/person-form.js",
+      "_max-chars.DwBgcc3G.min.js",
+      "_calendar.C4S5ojBx.min.js",
+      "_index.wj8pcfcc.min.js",
+      "_index.Bh91bsRU.min.js",
+      "_locale-resolver.D1koifEE.min.js",
+      "_fetch.Bc7I7bIE.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/app-detail.js": {
+    "file": "assets/app_detail.Bvpaj8Dj.min.js",
+    "name": "app_detail",
+    "src": "src/main/javascript/bundles/app-detail.js",
+    "isEntry": true,
+    "imports": [
+      "_jquery.CYvPhWWh.min.js",
+      "_send-get-days-request-for-turn-of-the-year.N0-OrWVW.min.js",
+      "_max-chars.DwBgcc3G.min.js",
+      "_fetch.Bc7I7bIE.min.js",
+      "_index.wj8pcfcc.min.js",
+      "_index.Bh91bsRU.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/app-form.js": {
+    "file": "assets/app_form.MtDaKpBi.min.js",
+    "name": "app_form",
+    "src": "src/main/javascript/bundles/app-form.js",
+    "isEntry": true,
+    "imports": [
+      "src/main/javascript/components/datepicker/index.js",
+      "_jquery.CYvPhWWh.min.js",
+      "_send-get-days-request-for-turn-of-the-year.N0-OrWVW.min.js",
+      "_fetch.Bc7I7bIE.min.js",
+      "_index.wj8pcfcc.min.js",
+      "_calendar.C4S5ojBx.min.js",
+      "src/main/javascript/bundles/person-form.js",
+      "_max-chars.DwBgcc3G.min.js",
+      "_locale-resolver.D1koifEE.min.js",
+      "_index.Bh91bsRU.min.js"
+    ],
+    "css": [
+      "assets/app_form._C7kVfoY.css"
+    ]
+  },
+  "src/main/javascript/bundles/app-list.js": {
+    "file": "assets/app_list.CFPNJ7BJ.min.js",
+    "name": "app_list",
+    "src": "src/main/javascript/bundles/app-list.js",
+    "isEntry": true,
+    "imports": [
+      "src/main/javascript/bundles/overtime-overview.js"
+    ]
+  },
+  "src/main/javascript/bundles/app-statistics.js": {
+    "file": "assets/app_statistics.BNsvJmQt.min.js",
+    "name": "app_statistics",
+    "src": "src/main/javascript/bundles/app-statistics.js",
+    "isEntry": true,
+    "imports": [
+      "_turbo.es2017-esm.DHvWW2v7.min.js",
+      "_turbo-before-render-restore.BN3LCdBL.min.js",
+      "_autosubmit.r8iHgQvC.min.js",
+      "src/main/javascript/components/datepicker/index.js",
+      "_hotwire-turbo-progressbar.CUHRTaOR.min.js",
+      "_calendar.C4S5ojBx.min.js",
+      "_index.wj8pcfcc.min.js",
+      "_index.Bh91bsRU.min.js",
+      "_locale-resolver.D1koifEE.min.js",
+      "_fetch.Bc7I7bIE.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/common.js": {
+    "file": "assets/common.CcPfV1tJ.min.js",
+    "name": "common",
+    "src": "src/main/javascript/bundles/common.js",
+    "isEntry": true,
+    "imports": [
+      "_jquery.CYvPhWWh.min.js",
+      "_tab.DRceIxvF.min.js",
+      "_tooltip.V9gAR6FA.min.js",
+      "_popover.ae9y68QG.min.js",
+      "_fetch.Bc7I7bIE.min.js",
+      "_index.D_CwqlHt.min.js"
+    ],
+    "css": [
+      "assets/common.TBP_tahU.css"
+    ]
+  },
+  "src/main/javascript/bundles/custom-elements-polyfill.js": {
+    "file": "assets/custom-elements-polyfill.DsniQcEy.min.js",
+    "name": "custom-elements-polyfill",
+    "src": "src/main/javascript/bundles/custom-elements-polyfill.js",
+    "isEntry": true
+  },
+  "src/main/javascript/bundles/datalist-polyfill.js": {
+    "file": "assets/datalist_polyfill.KsgG9JZ5.min.js",
+    "name": "datalist_polyfill",
+    "src": "src/main/javascript/bundles/datalist-polyfill.js",
+    "isEntry": true
+  },
+  "src/main/javascript/bundles/date-fns-localized.js": {
+    "file": "assets/date-fns-localized.b3e9seAS.min.js",
+    "name": "date-fns-localized",
+    "src": "src/main/javascript/bundles/date-fns-localized.js",
+    "isEntry": true,
+    "imports": [
+      "_locale-resolver.D1koifEE.min.js",
+      "_index.Bh91bsRU.min.js"
+    ],
+    "dynamicImports": [
+      "node_modules/date-fns/esm/locale/de-AT/index.js",
+      "node_modules/date-fns/esm/locale/de/index.js",
+      "node_modules/date-fns/esm/locale/en-GB/index.js",
+      "node_modules/date-fns/esm/locale/el/index.js"
+    ]
+  },
+  "src/main/javascript/bundles/department-form.js": {
+    "file": "assets/department_form.BqQUcWVm.min.js",
+    "name": "department_form",
+    "src": "src/main/javascript/bundles/department-form.js",
+    "isEntry": true,
+    "imports": [
+      "_turbo.es2017-esm.DHvWW2v7.min.js",
+      "src/main/javascript/bundles/person-form.js",
+      "_max-chars.DwBgcc3G.min.js",
+      "_autosubmit.r8iHgQvC.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/department-list.js": {
+    "file": "assets/department_list.DNNSEzhb.min.js",
+    "name": "department_list",
+    "src": "src/main/javascript/bundles/department-list.js",
+    "isEntry": true,
+    "imports": [
+      "_jquery.CYvPhWWh.min.js",
+      "_jquery.tablesorter.combined.D9ypodMB.min.js",
+      "_tooltip.V9gAR6FA.min.js",
+      "_popover.ae9y68QG.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/overtime-form.js": {
+    "file": "assets/overtime_form.BH1NpMRr.min.js",
+    "name": "overtime_form",
+    "src": "src/main/javascript/bundles/overtime-form.js",
+    "isEntry": true,
+    "imports": [
+      "_jquery.CYvPhWWh.min.js",
+      "src/main/javascript/components/datepicker/index.js",
+      "src/main/javascript/bundles/person-form.js",
+      "_max-chars.DwBgcc3G.min.js",
+      "_calendar.C4S5ojBx.min.js",
+      "_index.wj8pcfcc.min.js",
+      "_index.Bh91bsRU.min.js",
+      "_locale-resolver.D1koifEE.min.js",
+      "_fetch.Bc7I7bIE.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/overtime-overview.js": {
+    "file": "assets/overtime_overview.fP3sqvHh.min.js",
+    "name": "overtime_overview",
+    "src": "src/main/javascript/bundles/overtime-overview.js",
+    "isEntry": true
+  },
+  "src/main/javascript/bundles/person-basedata.js": {
+    "file": "assets/person_basedata.DnozbFB_.min.js",
+    "name": "person_basedata",
+    "src": "src/main/javascript/bundles/person-basedata.js",
+    "isEntry": true,
+    "imports": [
+      "_max-chars.DwBgcc3G.min.js",
+      "src/main/javascript/bundles/person-form.js"
+    ]
+  },
+  "src/main/javascript/bundles/person-form.js": {
+    "file": "assets/person_form.BWIoxKKn.min.js",
+    "name": "person_form",
+    "src": "src/main/javascript/bundles/person-form.js",
+    "isEntry": true
+  },
+  "src/main/javascript/bundles/person-notifications.js": {
+    "file": "assets/person_notifications.BIgiyQY2.min.js",
+    "name": "person_notifications",
+    "src": "src/main/javascript/bundles/person-notifications.js",
+    "isEntry": true,
+    "imports": [
+      "_turbo.es2017-esm.DHvWW2v7.min.js",
+      "_autosubmit.r8iHgQvC.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/person-overview.js": {
+    "file": "assets/person_overview.Dry8WyB5.min.js",
+    "name": "person_overview",
+    "src": "src/main/javascript/bundles/person-overview.js",
+    "isEntry": true,
+    "imports": [
+      "_jquery.CYvPhWWh.min.js",
+      "_fetch.Bc7I7bIE.min.js",
+      "_calendar.C4S5ojBx.min.js",
+      "_index.wj8pcfcc.min.js",
+      "_index.D_CwqlHt.min.js",
+      "_send-get-days-request-for-turn-of-the-year.N0-OrWVW.min.js",
+      "src/main/javascript/bundles/overtime-overview.js",
+      "_index.Bh91bsRU.min.js",
+      "_locale-resolver.D1koifEE.min.js",
+      "_tooltip.V9gAR6FA.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/person.js": {
+    "file": "assets/person.Px54RW3Q.min.js",
+    "name": "person",
+    "src": "src/main/javascript/bundles/person.js",
+    "isEntry": true,
+    "imports": [
+      "_turbo.es2017-esm.DHvWW2v7.min.js",
+      "_hotwire-turbo-progressbar.CUHRTaOR.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/persons.js": {
+    "file": "assets/persons.C9lhAwZH.min.js",
+    "name": "persons",
+    "src": "src/main/javascript/bundles/persons.js",
+    "isEntry": true,
+    "imports": [
+      "_turbo.es2017-esm.DHvWW2v7.min.js",
+      "_autosubmit.r8iHgQvC.min.js",
+      "_hotwire-turbo-progressbar.CUHRTaOR.min.js",
+      "src/main/javascript/bundles/overtime-overview.js"
+    ]
+  },
+  "src/main/javascript/bundles/polyfill.js": {
+    "file": "assets/polyfill.x_Mg-ijC.min.js",
+    "name": "polyfill",
+    "src": "src/main/javascript/bundles/polyfill.js",
+    "isEntry": true
+  },
+  "src/main/javascript/bundles/settings-form.js": {
+    "file": "assets/settings_form.BQg2oy_1.min.js",
+    "name": "settings_form",
+    "src": "src/main/javascript/bundles/settings-form.js",
+    "isEntry": true,
+    "imports": [
+      "src/main/javascript/components/tabs/index.js",
+      "_jquery.CYvPhWWh.min.js",
+      "_tab.DRceIxvF.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/sick-note-convert.js": {
+    "file": "assets/sick_note_convert.Blst47k7.min.js",
+    "name": "sick_note_convert",
+    "src": "src/main/javascript/bundles/sick-note-convert.js",
+    "isEntry": true,
+    "imports": [
+      "src/main/javascript/bundles/person-form.js",
+      "_max-chars.DwBgcc3G.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/sick-note-form.js": {
+    "file": "assets/sick_note_form.B7XCubhp.min.js",
+    "name": "sick_note_form",
+    "src": "src/main/javascript/bundles/sick-note-form.js",
+    "isEntry": true,
+    "imports": [
+      "_jquery.CYvPhWWh.min.js",
+      "src/main/javascript/components/datepicker/index.js",
+      "src/main/javascript/bundles/person-form.js",
+      "_max-chars.DwBgcc3G.min.js",
+      "_calendar.C4S5ojBx.min.js",
+      "_index.wj8pcfcc.min.js",
+      "_index.Bh91bsRU.min.js",
+      "_locale-resolver.D1koifEE.min.js",
+      "_fetch.Bc7I7bIE.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/sick-note.js": {
+    "file": "assets/sick_note.DYixFUDp.min.js",
+    "name": "sick_note",
+    "src": "src/main/javascript/bundles/sick-note.js",
+    "isEntry": true,
+    "imports": [
+      "_max-chars.DwBgcc3G.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/sick-notes.js": {
+    "file": "assets/sick_notes.cBwzFfph.min.js",
+    "name": "sick_notes",
+    "src": "src/main/javascript/bundles/sick-notes.js",
+    "isEntry": true,
+    "imports": [
+      "_turbo.es2017-esm.DHvWW2v7.min.js",
+      "_turbo-before-render-restore.BN3LCdBL.min.js",
+      "_autosubmit.r8iHgQvC.min.js",
+      "src/main/javascript/components/datepicker/index.js",
+      "_hotwire-turbo-progressbar.CUHRTaOR.min.js",
+      "src/main/javascript/bundles/overtime-overview.js",
+      "_calendar.C4S5ojBx.min.js",
+      "_index.wj8pcfcc.min.js",
+      "_index.Bh91bsRU.min.js",
+      "_locale-resolver.D1koifEE.min.js",
+      "_fetch.Bc7I7bIE.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/user-settings.js": {
+    "file": "assets/user_settings.C2AS5K0w.min.js",
+    "name": "user_settings",
+    "src": "src/main/javascript/bundles/user-settings.js",
+    "isEntry": true,
+    "imports": [
+      "_fetch.Bc7I7bIE.min.js",
+      "_index.D_CwqlHt.min.js",
+      "_jquery.CYvPhWWh.min.js",
+      "_tooltip.V9gAR6FA.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/workingtime-form.js": {
+    "file": "assets/workingtime_form.C2zkLMSM.min.js",
+    "name": "workingtime_form",
+    "src": "src/main/javascript/bundles/workingtime-form.js",
+    "isEntry": true,
+    "imports": [
+      "src/main/javascript/components/datepicker/index.js",
+      "src/main/javascript/bundles/person-form.js",
+      "_calendar.C4S5ojBx.min.js",
+      "_index.wj8pcfcc.min.js",
+      "_index.Bh91bsRU.min.js",
+      "_locale-resolver.D1koifEE.min.js",
+      "_fetch.Bc7I7bIE.min.js"
+    ]
+  },
+  "src/main/javascript/components/copy-to-clipboard-input/index.js": {
+    "file": "assets/copy_to_clipboard_input.DyRGKgyo.min.js",
+    "name": "copy_to_clipboard_input",
+    "src": "src/main/javascript/components/copy-to-clipboard-input/index.js",
+    "isEntry": true,
+    "imports": [
+      "_index.D_CwqlHt.min.js",
+      "_jquery.CYvPhWWh.min.js",
+      "_tooltip.V9gAR6FA.min.js"
+    ]
+  },
+  "src/main/javascript/components/datepicker/index.js": {
+    "file": "assets/datepicker.BjDyXs7e.min.js",
+    "name": "datepicker",
+    "src": "src/main/javascript/components/datepicker/index.js",
+    "isEntry": true,
+    "imports": [
+      "_calendar.C4S5ojBx.min.js",
+      "_locale-resolver.D1koifEE.min.js",
+      "_fetch.Bc7I7bIE.min.js",
+      "_index.wj8pcfcc.min.js",
+      "_index.Bh91bsRU.min.js"
+    ],
+    "css": [
+      "assets/datepicker.Dpt7jkcJ.css"
+    ]
+  },
+  "src/main/javascript/components/tabs/index.js": {
+    "file": "assets/tabs.B_PQeATH.min.js",
+    "name": "tabs",
+    "src": "src/main/javascript/components/tabs/index.js",
+    "isEntry": true,
+    "imports": [
+      "_jquery.CYvPhWWh.min.js",
+      "_tab.DRceIxvF.min.js"
+    ]
+  }
+}

--- a/vite-spring-boot/src/main/java/io/github/wimdeblauwe/vite/spring/boot/ViteLinkResolver.java
+++ b/vite-spring-boot/src/main/java/io/github/wimdeblauwe/vite/spring/boot/ViteLinkResolver.java
@@ -62,6 +62,22 @@ public class ViteLinkResolver {
     }
   }
 
+  /**
+   * Resolves a path that is already a built asset path (e.g. from a manifest entry's {@code css} array).
+   * These paths don't need to be looked up in the manifest again, they just need the context path prepended.
+   */
+  public String resolveBuiltAssetPath(String builtPath) {
+    StringBuilder builder = new StringBuilder();
+    if (properties.buildModeContextPath() != null) {
+      builder.append(properties.buildModeContextPath())
+          .append("/");
+    } else {
+      builder.append("/");
+    }
+    builder.append(builtPath);
+    return builder.toString();
+  }
+
   public ManifestEntry getManifestEntry(String resource) {
     ManifestEntry manifestEntry = manifestReader.getManifestEntry(prependWithPrefix(resource));
     if (manifestEntry == null) {

--- a/vite-spring-boot/src/test/java/io/github/wimdeblauwe/vite/spring/boot/ViteLinkResolverTest.java
+++ b/vite-spring-boot/src/test/java/io/github/wimdeblauwe/vite/spring/boot/ViteLinkResolverTest.java
@@ -78,13 +78,66 @@ class ViteLinkResolverTest {
     }
   }
 
+  @Nested
+  class Issue19Tests {
+    @Test
+    void testGetManifestEntryWithCssArray() throws IOException {
+      ViteLinkResolver resolver = createLinkResolverForIssue19();
+      ViteManifestReader.ManifestEntry entry = resolver.getManifestEntry("bundles/app-form.js");
+      assertThat(entry).isNotNull();
+      assertThat(entry.css()).containsExactly("assets/app_form._C7kVfoY.css");
+    }
+
+    @Test
+    void testResolveBuiltAssetPath() throws IOException {
+      ViteLinkResolver resolver = createLinkResolverForIssue19();
+      // CSS paths from manifest css arrays are already built paths
+      // They should be resolvable without going through the manifest again
+      String resolved = resolver.resolveBuiltAssetPath("assets/app_form._C7kVfoY.css");
+      assertThat(resolved).isEqualTo("/assets/app_form._C7kVfoY.css");
+    }
+
+    @Test
+    void testResolveBuiltAssetPathWithContextPath() throws IOException {
+      ViteConfigurationProperties properties = new ViteConfigurationProperties(
+              ViteConfigurationProperties.Mode.BUILD,
+              new ClassPathResource("io/github/wimdeblauwe/vite/spring/boot/vite-manifest-issue-19.json"),
+              null, "src/main/javascript", "/build-context", null);
+      ViteManifestReader manifestReader = new ViteManifestReader(jsonMapper, properties);
+      manifestReader.init();
+      ViteLinkResolver resolver = new ViteLinkResolver(properties,
+              new ViteDevServerConfigurationProperties("localhost", 5173),
+              manifestReader);
+
+      String resolved = resolver.resolveBuiltAssetPath("assets/app_form._C7kVfoY.css");
+      assertThat(resolved).isEqualTo("/build-context/assets/app_form._C7kVfoY.css");
+    }
+  }
+
   private ViteLinkResolver createLinkResolver(ViteConfigurationProperties.Mode mode) throws IOException {
-    ViteConfigurationProperties properties = new ViteConfigurationProperties(mode, new ClassPathResource("io/github/wimdeblauwe/vite/spring/boot/vite-manifest-example.json"), null, "static", null, null);
+    return createLinkResolver(mode, new ClassPathResource("io/github/wimdeblauwe/vite/spring/boot/vite-manifest-example.json"));
+  }
+
+  private ViteLinkResolver createLinkResolver(ViteConfigurationProperties.Mode mode,
+                                              ClassPathResource manifestResource) throws IOException {
+    return createLinkResolver(mode, manifestResource, "static");
+  }
+
+  private ViteLinkResolver createLinkResolver(ViteConfigurationProperties.Mode mode,
+                                              ClassPathResource manifestResource,
+                                              String prefix) throws IOException {
+    ViteConfigurationProperties properties = new ViteConfigurationProperties(mode, manifestResource, null, prefix, null, null);
     ViteManifestReader manifestReader = new ViteManifestReader(jsonMapper, properties);
     manifestReader.init();
     return new ViteLinkResolver(properties,
             new ViteDevServerConfigurationProperties("localhost", 5173),
             manifestReader);
+  }
+
+  private ViteLinkResolver createLinkResolverForIssue19() throws IOException {
+    return createLinkResolver(ViteConfigurationProperties.Mode.BUILD,
+            new ClassPathResource("io/github/wimdeblauwe/vite/spring/boot/vite-manifest-issue-19.json"),
+            "src/main/javascript");
   }
 
   private ViteLinkResolver createLinkResolverWithCustomContextPaths(ViteConfigurationProperties.Mode mode) throws IOException {

--- a/vite-spring-boot/src/test/resources/io/github/wimdeblauwe/vite/spring/boot/vite-manifest-issue-19.json
+++ b/vite-spring-boot/src/test/resources/io/github/wimdeblauwe/vite/spring/boot/vite-manifest-issue-19.json
@@ -1,0 +1,545 @@
+{
+  "_autosubmit.r8iHgQvC.min.js": {
+    "file": "assets/autosubmit.r8iHgQvC.min.js",
+    "name": "autosubmit"
+  },
+  "_calendar.C4S5ojBx.min.js": {
+    "file": "assets/calendar.C4S5ojBx.min.js",
+    "name": "calendar",
+    "imports": [
+      "_index.wj8pcfcc.min.js",
+      "_index.Bh91bsRU.min.js",
+      "_locale-resolver.D1koifEE.min.js",
+      "_fetch.Bc7I7bIE.min.js"
+    ],
+    "css": [
+      "assets/calendar.fn7WE02H.css"
+    ]
+  },
+  "_calendar.fn7WE02H.css": {
+    "file": "assets/calendar.fn7WE02H.css",
+    "src": "_calendar.fn7WE02H.css"
+  },
+  "_fetch.Bc7I7bIE.min.js": {
+    "file": "assets/fetch.Bc7I7bIE.min.js",
+    "name": "fetch"
+  },
+  "_hotwire-turbo-progressbar.CUHRTaOR.min.js": {
+    "file": "assets/hotwire-turbo-progressbar.CUHRTaOR.min.js",
+    "name": "hotwire-turbo-progressbar",
+    "imports": [
+      "_turbo.es2017-esm.DHvWW2v7.min.js"
+    ]
+  },
+  "_index.BCp-oihN.min.js": {
+    "file": "assets/index.BCp-oihN.min.js",
+    "name": "index",
+    "imports": [
+      "_index.Bh91bsRU.min.js"
+    ]
+  },
+  "_index.Bh91bsRU.min.js": {
+    "file": "assets/index.Bh91bsRU.min.js",
+    "name": "index"
+  },
+  "_index.D_CwqlHt.min.js": {
+    "file": "assets/index.D_CwqlHt.min.js",
+    "name": "index",
+    "imports": [
+      "_jquery.CYvPhWWh.min.js",
+      "_tooltip.V9gAR6FA.min.js"
+    ]
+  },
+  "_index.wj8pcfcc.min.js": {
+    "file": "assets/index.wj8pcfcc.min.js",
+    "name": "index",
+    "imports": [
+      "_index.Bh91bsRU.min.js"
+    ]
+  },
+  "_jquery.CYvPhWWh.min.js": {
+    "file": "assets/jquery.CYvPhWWh.min.js",
+    "name": "jquery"
+  },
+  "_jquery.tablesorter.combined.D9ypodMB.min.js": {
+    "file": "assets/jquery.tablesorter.combined.D9ypodMB.min.js",
+    "name": "jquery.tablesorter.combined",
+    "imports": [
+      "_jquery.CYvPhWWh.min.js"
+    ]
+  },
+  "_locale-resolver.D1koifEE.min.js": {
+    "file": "assets/locale-resolver.D1koifEE.min.js",
+    "name": "locale-resolver",
+    "imports": [
+      "_index.Bh91bsRU.min.js"
+    ]
+  },
+  "_max-chars.DwBgcc3G.min.js": {
+    "file": "assets/max-chars.DwBgcc3G.min.js",
+    "name": "max-chars"
+  },
+  "_popover.ae9y68QG.min.js": {
+    "file": "assets/popover.ae9y68QG.min.js",
+    "name": "popover",
+    "imports": [
+      "_jquery.CYvPhWWh.min.js"
+    ]
+  },
+  "_send-get-days-request-for-turn-of-the-year.N0-OrWVW.min.js": {
+    "file": "assets/send-get-days-request-for-turn-of-the-year.N0-OrWVW.min.js",
+    "name": "send-get-days-request-for-turn-of-the-year",
+    "imports": [
+      "_fetch.Bc7I7bIE.min.js",
+      "_index.wj8pcfcc.min.js"
+    ]
+  },
+  "_tab.DRceIxvF.min.js": {
+    "file": "assets/tab.DRceIxvF.min.js",
+    "name": "tab",
+    "imports": [
+      "_jquery.CYvPhWWh.min.js"
+    ]
+  },
+  "_tooltip.V9gAR6FA.min.js": {
+    "file": "assets/tooltip.V9gAR6FA.min.js",
+    "name": "tooltip",
+    "imports": [
+      "_jquery.CYvPhWWh.min.js"
+    ]
+  },
+  "_turbo-before-render-restore.BN3LCdBL.min.js": {
+    "file": "assets/turbo-before-render-restore.BN3LCdBL.min.js",
+    "name": "turbo-before-render-restore",
+    "imports": [
+      "src/main/javascript/components/datepicker/index.js"
+    ]
+  },
+  "_turbo.es2017-esm.DHvWW2v7.min.js": {
+    "file": "assets/turbo.es2017-esm.DHvWW2v7.min.js",
+    "name": "turbo.es2017-esm"
+  },
+  "node_modules/date-fns/esm/locale/de-AT/index.js": {
+    "file": "assets/index.DSg2a4Uh.min.js",
+    "name": "index",
+    "src": "node_modules/date-fns/esm/locale/de-AT/index.js",
+    "isDynamicEntry": true,
+    "imports": [
+      "_index.BCp-oihN.min.js",
+      "_index.Bh91bsRU.min.js"
+    ]
+  },
+  "node_modules/date-fns/esm/locale/de/index.js": {
+    "file": "assets/index.E_D5Olis.min.js",
+    "name": "index",
+    "src": "node_modules/date-fns/esm/locale/de/index.js",
+    "isDynamicEntry": true,
+    "imports": [
+      "_index.BCp-oihN.min.js",
+      "_index.Bh91bsRU.min.js"
+    ]
+  },
+  "node_modules/date-fns/esm/locale/el/index.js": {
+    "file": "assets/index.yT1O6zju.min.js",
+    "name": "index",
+    "src": "node_modules/date-fns/esm/locale/el/index.js",
+    "isDynamicEntry": true,
+    "imports": [
+      "_index.Bh91bsRU.min.js"
+    ]
+  },
+  "node_modules/date-fns/esm/locale/en-GB/index.js": {
+    "file": "assets/index.CMH_g7DM.min.js",
+    "name": "index",
+    "src": "node_modules/date-fns/esm/locale/en-GB/index.js",
+    "isDynamicEntry": true,
+    "imports": [
+      "_index.Bh91bsRU.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/absences-overview.js": {
+    "file": "assets/absences_overview.DnLNFLkL.min.js",
+    "name": "absences_overview",
+    "src": "src/main/javascript/bundles/absences-overview.js",
+    "isEntry": true,
+    "imports": [
+      "_jquery.CYvPhWWh.min.js",
+      "_jquery.tablesorter.combined.D9ypodMB.min.js"
+    ],
+    "css": [
+      "assets/absences_overview.D3I0_cTc.css"
+    ]
+  },
+  "src/main/javascript/bundles/account-form.js": {
+    "file": "assets/account_form.DciBKjhr.min.js",
+    "name": "account_form",
+    "src": "src/main/javascript/bundles/account-form.js",
+    "isEntry": true,
+    "imports": [
+      "src/main/javascript/components/datepicker/index.js",
+      "src/main/javascript/bundles/person-form.js",
+      "_max-chars.DwBgcc3G.min.js",
+      "_calendar.C4S5ojBx.min.js",
+      "_index.wj8pcfcc.min.js",
+      "_index.Bh91bsRU.min.js",
+      "_locale-resolver.D1koifEE.min.js",
+      "_fetch.Bc7I7bIE.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/app-detail.js": {
+    "file": "assets/app_detail.Bvpaj8Dj.min.js",
+    "name": "app_detail",
+    "src": "src/main/javascript/bundles/app-detail.js",
+    "isEntry": true,
+    "imports": [
+      "_jquery.CYvPhWWh.min.js",
+      "_send-get-days-request-for-turn-of-the-year.N0-OrWVW.min.js",
+      "_max-chars.DwBgcc3G.min.js",
+      "_fetch.Bc7I7bIE.min.js",
+      "_index.wj8pcfcc.min.js",
+      "_index.Bh91bsRU.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/app-form.js": {
+    "file": "assets/app_form.MtDaKpBi.min.js",
+    "name": "app_form",
+    "src": "src/main/javascript/bundles/app-form.js",
+    "isEntry": true,
+    "imports": [
+      "src/main/javascript/components/datepicker/index.js",
+      "_jquery.CYvPhWWh.min.js",
+      "_send-get-days-request-for-turn-of-the-year.N0-OrWVW.min.js",
+      "_fetch.Bc7I7bIE.min.js",
+      "_index.wj8pcfcc.min.js",
+      "_calendar.C4S5ojBx.min.js",
+      "src/main/javascript/bundles/person-form.js",
+      "_max-chars.DwBgcc3G.min.js",
+      "_locale-resolver.D1koifEE.min.js",
+      "_index.Bh91bsRU.min.js"
+    ],
+    "css": [
+      "assets/app_form._C7kVfoY.css"
+    ]
+  },
+  "src/main/javascript/bundles/app-list.js": {
+    "file": "assets/app_list.CFPNJ7BJ.min.js",
+    "name": "app_list",
+    "src": "src/main/javascript/bundles/app-list.js",
+    "isEntry": true,
+    "imports": [
+      "src/main/javascript/bundles/overtime-overview.js"
+    ]
+  },
+  "src/main/javascript/bundles/app-statistics.js": {
+    "file": "assets/app_statistics.BNsvJmQt.min.js",
+    "name": "app_statistics",
+    "src": "src/main/javascript/bundles/app-statistics.js",
+    "isEntry": true,
+    "imports": [
+      "_turbo.es2017-esm.DHvWW2v7.min.js",
+      "_turbo-before-render-restore.BN3LCdBL.min.js",
+      "_autosubmit.r8iHgQvC.min.js",
+      "src/main/javascript/components/datepicker/index.js",
+      "_hotwire-turbo-progressbar.CUHRTaOR.min.js",
+      "_calendar.C4S5ojBx.min.js",
+      "_index.wj8pcfcc.min.js",
+      "_index.Bh91bsRU.min.js",
+      "_locale-resolver.D1koifEE.min.js",
+      "_fetch.Bc7I7bIE.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/common.js": {
+    "file": "assets/common.CcPfV1tJ.min.js",
+    "name": "common",
+    "src": "src/main/javascript/bundles/common.js",
+    "isEntry": true,
+    "imports": [
+      "_jquery.CYvPhWWh.min.js",
+      "_tab.DRceIxvF.min.js",
+      "_tooltip.V9gAR6FA.min.js",
+      "_popover.ae9y68QG.min.js",
+      "_fetch.Bc7I7bIE.min.js",
+      "_index.D_CwqlHt.min.js"
+    ],
+    "css": [
+      "assets/common.TBP_tahU.css"
+    ]
+  },
+  "src/main/javascript/bundles/custom-elements-polyfill.js": {
+    "file": "assets/custom-elements-polyfill.DsniQcEy.min.js",
+    "name": "custom-elements-polyfill",
+    "src": "src/main/javascript/bundles/custom-elements-polyfill.js",
+    "isEntry": true
+  },
+  "src/main/javascript/bundles/datalist-polyfill.js": {
+    "file": "assets/datalist_polyfill.KsgG9JZ5.min.js",
+    "name": "datalist_polyfill",
+    "src": "src/main/javascript/bundles/datalist-polyfill.js",
+    "isEntry": true
+  },
+  "src/main/javascript/bundles/date-fns-localized.js": {
+    "file": "assets/date-fns-localized.b3e9seAS.min.js",
+    "name": "date-fns-localized",
+    "src": "src/main/javascript/bundles/date-fns-localized.js",
+    "isEntry": true,
+    "imports": [
+      "_locale-resolver.D1koifEE.min.js",
+      "_index.Bh91bsRU.min.js"
+    ],
+    "dynamicImports": [
+      "node_modules/date-fns/esm/locale/de-AT/index.js",
+      "node_modules/date-fns/esm/locale/de/index.js",
+      "node_modules/date-fns/esm/locale/en-GB/index.js",
+      "node_modules/date-fns/esm/locale/el/index.js"
+    ]
+  },
+  "src/main/javascript/bundles/department-form.js": {
+    "file": "assets/department_form.BqQUcWVm.min.js",
+    "name": "department_form",
+    "src": "src/main/javascript/bundles/department-form.js",
+    "isEntry": true,
+    "imports": [
+      "_turbo.es2017-esm.DHvWW2v7.min.js",
+      "src/main/javascript/bundles/person-form.js",
+      "_max-chars.DwBgcc3G.min.js",
+      "_autosubmit.r8iHgQvC.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/department-list.js": {
+    "file": "assets/department_list.DNNSEzhb.min.js",
+    "name": "department_list",
+    "src": "src/main/javascript/bundles/department-list.js",
+    "isEntry": true,
+    "imports": [
+      "_jquery.CYvPhWWh.min.js",
+      "_jquery.tablesorter.combined.D9ypodMB.min.js",
+      "_tooltip.V9gAR6FA.min.js",
+      "_popover.ae9y68QG.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/overtime-form.js": {
+    "file": "assets/overtime_form.BH1NpMRr.min.js",
+    "name": "overtime_form",
+    "src": "src/main/javascript/bundles/overtime-form.js",
+    "isEntry": true,
+    "imports": [
+      "_jquery.CYvPhWWh.min.js",
+      "src/main/javascript/components/datepicker/index.js",
+      "src/main/javascript/bundles/person-form.js",
+      "_max-chars.DwBgcc3G.min.js",
+      "_calendar.C4S5ojBx.min.js",
+      "_index.wj8pcfcc.min.js",
+      "_index.Bh91bsRU.min.js",
+      "_locale-resolver.D1koifEE.min.js",
+      "_fetch.Bc7I7bIE.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/overtime-overview.js": {
+    "file": "assets/overtime_overview.fP3sqvHh.min.js",
+    "name": "overtime_overview",
+    "src": "src/main/javascript/bundles/overtime-overview.js",
+    "isEntry": true
+  },
+  "src/main/javascript/bundles/person-basedata.js": {
+    "file": "assets/person_basedata.DnozbFB_.min.js",
+    "name": "person_basedata",
+    "src": "src/main/javascript/bundles/person-basedata.js",
+    "isEntry": true,
+    "imports": [
+      "_max-chars.DwBgcc3G.min.js",
+      "src/main/javascript/bundles/person-form.js"
+    ]
+  },
+  "src/main/javascript/bundles/person-form.js": {
+    "file": "assets/person_form.BWIoxKKn.min.js",
+    "name": "person_form",
+    "src": "src/main/javascript/bundles/person-form.js",
+    "isEntry": true
+  },
+  "src/main/javascript/bundles/person-notifications.js": {
+    "file": "assets/person_notifications.BIgiyQY2.min.js",
+    "name": "person_notifications",
+    "src": "src/main/javascript/bundles/person-notifications.js",
+    "isEntry": true,
+    "imports": [
+      "_turbo.es2017-esm.DHvWW2v7.min.js",
+      "_autosubmit.r8iHgQvC.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/person-overview.js": {
+    "file": "assets/person_overview.Dry8WyB5.min.js",
+    "name": "person_overview",
+    "src": "src/main/javascript/bundles/person-overview.js",
+    "isEntry": true,
+    "imports": [
+      "_jquery.CYvPhWWh.min.js",
+      "_fetch.Bc7I7bIE.min.js",
+      "_calendar.C4S5ojBx.min.js",
+      "_index.wj8pcfcc.min.js",
+      "_index.D_CwqlHt.min.js",
+      "_send-get-days-request-for-turn-of-the-year.N0-OrWVW.min.js",
+      "src/main/javascript/bundles/overtime-overview.js",
+      "_index.Bh91bsRU.min.js",
+      "_locale-resolver.D1koifEE.min.js",
+      "_tooltip.V9gAR6FA.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/person.js": {
+    "file": "assets/person.Px54RW3Q.min.js",
+    "name": "person",
+    "src": "src/main/javascript/bundles/person.js",
+    "isEntry": true,
+    "imports": [
+      "_turbo.es2017-esm.DHvWW2v7.min.js",
+      "_hotwire-turbo-progressbar.CUHRTaOR.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/persons.js": {
+    "file": "assets/persons.C9lhAwZH.min.js",
+    "name": "persons",
+    "src": "src/main/javascript/bundles/persons.js",
+    "isEntry": true,
+    "imports": [
+      "_turbo.es2017-esm.DHvWW2v7.min.js",
+      "_autosubmit.r8iHgQvC.min.js",
+      "_hotwire-turbo-progressbar.CUHRTaOR.min.js",
+      "src/main/javascript/bundles/overtime-overview.js"
+    ]
+  },
+  "src/main/javascript/bundles/polyfill.js": {
+    "file": "assets/polyfill.x_Mg-ijC.min.js",
+    "name": "polyfill",
+    "src": "src/main/javascript/bundles/polyfill.js",
+    "isEntry": true
+  },
+  "src/main/javascript/bundles/settings-form.js": {
+    "file": "assets/settings_form.BQg2oy_1.min.js",
+    "name": "settings_form",
+    "src": "src/main/javascript/bundles/settings-form.js",
+    "isEntry": true,
+    "imports": [
+      "src/main/javascript/components/tabs/index.js",
+      "_jquery.CYvPhWWh.min.js",
+      "_tab.DRceIxvF.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/sick-note-convert.js": {
+    "file": "assets/sick_note_convert.Blst47k7.min.js",
+    "name": "sick_note_convert",
+    "src": "src/main/javascript/bundles/sick-note-convert.js",
+    "isEntry": true,
+    "imports": [
+      "src/main/javascript/bundles/person-form.js",
+      "_max-chars.DwBgcc3G.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/sick-note-form.js": {
+    "file": "assets/sick_note_form.B7XCubhp.min.js",
+    "name": "sick_note_form",
+    "src": "src/main/javascript/bundles/sick-note-form.js",
+    "isEntry": true,
+    "imports": [
+      "_jquery.CYvPhWWh.min.js",
+      "src/main/javascript/components/datepicker/index.js",
+      "src/main/javascript/bundles/person-form.js",
+      "_max-chars.DwBgcc3G.min.js",
+      "_calendar.C4S5ojBx.min.js",
+      "_index.wj8pcfcc.min.js",
+      "_index.Bh91bsRU.min.js",
+      "_locale-resolver.D1koifEE.min.js",
+      "_fetch.Bc7I7bIE.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/sick-note.js": {
+    "file": "assets/sick_note.DYixFUDp.min.js",
+    "name": "sick_note",
+    "src": "src/main/javascript/bundles/sick-note.js",
+    "isEntry": true,
+    "imports": [
+      "_max-chars.DwBgcc3G.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/sick-notes.js": {
+    "file": "assets/sick_notes.cBwzFfph.min.js",
+    "name": "sick_notes",
+    "src": "src/main/javascript/bundles/sick-notes.js",
+    "isEntry": true,
+    "imports": [
+      "_turbo.es2017-esm.DHvWW2v7.min.js",
+      "_turbo-before-render-restore.BN3LCdBL.min.js",
+      "_autosubmit.r8iHgQvC.min.js",
+      "src/main/javascript/components/datepicker/index.js",
+      "_hotwire-turbo-progressbar.CUHRTaOR.min.js",
+      "src/main/javascript/bundles/overtime-overview.js",
+      "_calendar.C4S5ojBx.min.js",
+      "_index.wj8pcfcc.min.js",
+      "_index.Bh91bsRU.min.js",
+      "_locale-resolver.D1koifEE.min.js",
+      "_fetch.Bc7I7bIE.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/user-settings.js": {
+    "file": "assets/user_settings.C2AS5K0w.min.js",
+    "name": "user_settings",
+    "src": "src/main/javascript/bundles/user-settings.js",
+    "isEntry": true,
+    "imports": [
+      "_fetch.Bc7I7bIE.min.js",
+      "_index.D_CwqlHt.min.js",
+      "_jquery.CYvPhWWh.min.js",
+      "_tooltip.V9gAR6FA.min.js"
+    ]
+  },
+  "src/main/javascript/bundles/workingtime-form.js": {
+    "file": "assets/workingtime_form.C2zkLMSM.min.js",
+    "name": "workingtime_form",
+    "src": "src/main/javascript/bundles/workingtime-form.js",
+    "isEntry": true,
+    "imports": [
+      "src/main/javascript/components/datepicker/index.js",
+      "src/main/javascript/bundles/person-form.js",
+      "_calendar.C4S5ojBx.min.js",
+      "_index.wj8pcfcc.min.js",
+      "_index.Bh91bsRU.min.js",
+      "_locale-resolver.D1koifEE.min.js",
+      "_fetch.Bc7I7bIE.min.js"
+    ]
+  },
+  "src/main/javascript/components/copy-to-clipboard-input/index.js": {
+    "file": "assets/copy_to_clipboard_input.DyRGKgyo.min.js",
+    "name": "copy_to_clipboard_input",
+    "src": "src/main/javascript/components/copy-to-clipboard-input/index.js",
+    "isEntry": true,
+    "imports": [
+      "_index.D_CwqlHt.min.js",
+      "_jquery.CYvPhWWh.min.js",
+      "_tooltip.V9gAR6FA.min.js"
+    ]
+  },
+  "src/main/javascript/components/datepicker/index.js": {
+    "file": "assets/datepicker.BjDyXs7e.min.js",
+    "name": "datepicker",
+    "src": "src/main/javascript/components/datepicker/index.js",
+    "isEntry": true,
+    "imports": [
+      "_calendar.C4S5ojBx.min.js",
+      "_locale-resolver.D1koifEE.min.js",
+      "_fetch.Bc7I7bIE.min.js",
+      "_index.wj8pcfcc.min.js",
+      "_index.Bh91bsRU.min.js"
+    ],
+    "css": [
+      "assets/datepicker.Dpt7jkcJ.css"
+    ]
+  },
+  "src/main/javascript/components/tabs/index.js": {
+    "file": "assets/tabs.B_PQeATH.min.js",
+    "name": "tabs",
+    "src": "src/main/javascript/components/tabs/index.js",
+    "isEntry": true,
+    "imports": [
+      "_jquery.CYvPhWWh.min.js",
+      "_tab.DRceIxvF.min.js"
+    ]
+  }
+}


### PR DESCRIPTION
… correctly

fixes #19

The code was written by Claude Code and this was its summary:

```
All 22 tests pass across all 3 modules. Here's a summary of the changes:                                                                                                                                                                         
                                                                                                                                                                                                                                                   
  Changes made to fix issue #19                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                   
  Root cause: CSS paths in a manifest entry's css array (e.g. assets/app_form._C7kVfoY.css) are already built asset paths, not source paths. They don't exist as standalone manifest keys, so they can't be resolved via                           
  resolveResource()/getBundledPath().                                                                                                                                                                                                              
                                                                                                                                                                                                                                                   
  3 fixes applied:                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                 
  1. ViteLinkResolver.java - Added resolveBuiltAssetPath(String) method that takes an already-built asset path and just prepends the context path prefix (/ or /build-context/). This avoids a redundant manifest lookup.                          
  2. ViteTagProcessor.java (Thymeleaf module) - Two fixes:
    - CSS from manifestEntry.css() now uses resolveBuiltAssetPath instead of resolveResource, and deduplicates by the CSS path (linkedCss) instead of the JS entry (value)                                                                         
    - CSS from imported chunks also uses resolveBuiltAssetPath instead of raw path, ensuring proper / prefix                                                                                                                                       
  3. ViteJteEntriesHandler.java (JTE module) - Same pattern: extracted addBuiltCssIfMissing() that uses resolveBuiltAssetPath for CSS from both direct entry and imported chunk css arrays                                                         
                                                                                                                                                                                                                                                   
  Tests added:                                                                                                                                                                                                                                     
  - 3 tests in ViteLinkResolverTest.Issue19Tests - manifest entry CSS array, resolveBuiltAssetPath, and context path variant                                                                                                                       
  - 3 tests in ViteTagProcessorTest - CSS emission from entry CSS arrays and imported chunks                   
  ```